### PR TITLE
Fix compiling on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.0)
 project (ipsnect)
 
 set(CMAKE_BUILD_TYPE Debug)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -static-libgcc -static-libstdc++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -static-libstdc++")
 
 file(GLOB _SRC
     "*.cpp"

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 
 using namespace std;
 
-const char* VERSION = "ipsnect utility v1.01";
+const char* VERSION = "ipsnect utility v1.03";
 
 struct Hunk
 {


### PR DESCRIPTION
Closes #4

Also updated the version to 1.03.

I tested compilation on my Intel Mac and on an x64 Ubuntu install and it works.

I also attached a Mac binary to this PR. It was compiled on an Intel Mac, so it may not run on ARM Macs. Or rather it will probably run, but I presume it will run through the Rosetta emulator. I will need to find an ARM Mac to do a build specific for ARM Macs.

I recommend compiling a Linux and Windows version and doing a 1.03 release.

[ipsnect-mac.zip](https://github.com/nstbayless/ipsnect/files/12444540/ipsnect-mac.zip)